### PR TITLE
Updated bridge-mappings from physnet1:br-data to physnet1:br-ex.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ options:
       within an OpenStack cloud.
   bridge-mappings:
     type: string
-    default: 'physnet1:br-data'
+    default: 'physnet1:br-ex'
     description: |
       Space-delimited list of ML2 data bridge mappings with format
       <provider>:<bridge>.


### PR DESCRIPTION
This matched the 'assumed' setting from the bundle/openstack-54, where it used br-ex for physnet1. The basic configuration example/documentation on the project page seems also to reference the usage of br-ex not br-data for the first network.